### PR TITLE
Marker : Fix typing

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,13 +5,13 @@ import { calculateMarkerPosition } from './utils';
 const DEFAULT_BUFFER = 12;
 
 export type Marker = {
-    top: Number;
-    left: Number;
+    top: number;
+    left: number;
 };
 export type MarkerComponentProps = {
-    top: Number;
-    left: Number;
-    itemNumber: Number;
+    top: number;
+    left: number;
+    itemNumber: number;
 };
 
 type Props = {


### PR DESCRIPTION
Hi,
It solves this error:
```
error TS2345: Argument of type 'Marker' is not assignable to parameter of type '{ top: number; left: number; }'.
   Types of property 'top' are incompatible.
     Type 'Number' is not assignable to type 'number'.
       'number' is a primitive, but 'Number' is a wrapper object. Prefer using 'number' when possible.
```
